### PR TITLE
Take a `&str` rather than a `String`

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,8 +7,7 @@ Turn pinyin written with tone numbers and turn it into pinyin with node marks. p
 ```rust
 use prettify_pinyin::prettify;
 
-let test = String::from("ma1 ma2 ma3 ma4 ma");
-let formatted: String = prettify(test);
+let formatted: String = prettify("ma1 ma2 ma3 ma4 ma");
 
 println!("{}", formatted); // --> mā má mǎ mà ma
 ```

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -12,8 +12,7 @@
 //! ```rust
 //! use prettify_pinyin::prettify;
 //!
-//! let test = String::from("ma1 ma2 ma3 ma4 ma");
-//! let formatted: String = prettify(test);
+//! let formatted: String = prettify("ma1 ma2 ma3 ma4 ma");
 //!
 //! println!("{}", formatted); // --> mā má mǎ mà ma
 //! ```
@@ -26,43 +25,43 @@ mod tests {
 
     #[test]
     fn prettify_basic() {
-        let hello = String::from("nǐ hǎo");
-        let china = String::from("zhōng guó");
-        let all_tones = String::from("mā má mǎ mà");
-        let no_tones = String::from("ma");
-        let capital_letter = String::from("Ān huī");
-        let yelling = String::from("NǏ HǍO ZHŌNG GUÓ");
+        let hello = "nǐ hǎo";
+        let china = "zhōng guó";
+        let all_tones = "mā má mǎ mà";
+        let no_tones = "ma";
+        let capital_letter = "Ān huī";
+        let yelling = "NǏ HǍO ZHŌNG GUÓ";
 
-        assert_eq!(hello, prettify(String::from("ni3 hao3")));
-        assert_eq!(china, prettify(String::from("zhong1 guo2")));
-        assert_eq!(all_tones, prettify(String::from("ma1 ma2 ma3 ma4")));
-        assert_eq!(no_tones, prettify(String::from("ma")));
-        assert_eq!(capital_letter, prettify(String::from("An1 hui1")));
-        assert_eq!(yelling, prettify(String::from("NI3 HAO3 ZHONG1 GUO2")));
+        assert_eq!(hello, prettify("ni3 hao3"));
+        assert_eq!(china, prettify("zhong1 guo2"));
+        assert_eq!(all_tones, prettify("ma1 ma2 ma3 ma4"));
+        assert_eq!(no_tones, prettify("ma"));
+        assert_eq!(capital_letter, prettify("An1 hui1"));
+        assert_eq!(yelling, prettify("NI3 HAO3 ZHONG1 GUO2"));
     }
 
     #[test]
     fn prettify_umlaut() {
-        assert_eq!("nǚ nǚ", prettify(String::from("nu:3 nu:3")));
-        assert_eq!("NǙ", prettify(String::from("NU:3")));
-        assert_eq!("nǚ NǙ", prettify(String::from("nu:3 NU:3")));
+        assert_eq!("nǚ nǚ", prettify("nu:3 nu:3"));
+        assert_eq!("NǙ", prettify("NU:3"));
+        assert_eq!("nǚ NǙ", prettify("nu:3 NU:3"));
     }
 
     #[test]
     fn invalid_tone() {
-        assert_eq!("ni7", prettify(String::from("ni7")));
+        assert_eq!("ni7", prettify("ni7"));
     }
 
     #[test]
     fn clear_tones() {
-        assert_eq!("ni", prettify(String::from("nǐ5")));
-        assert_eq!("nǚ nü", prettify(String::from("nǚ nǚ5")));
+        assert_eq!("ni", prettify("nǐ5"));
+        assert_eq!("nǚ nü", prettify("nǚ nǚ5"));
     }
 
     #[test]
     fn reassign_tones() {
-        assert_eq!("nī", prettify(String::from("nǐ1")));
-        assert_eq!("nǘ nǜ", prettify(String::from("nǚ2 nǚ4")));
+        assert_eq!("nī", prettify("nǐ1"));
+        assert_eq!("nǘ nǜ", prettify("nǚ2 nǚ4"));
     }
 }
 
@@ -103,9 +102,9 @@ fn clear_tone_mark(input: char) -> char {
 /// # prettify
 /// ```
 /// use prettify_pinyin::prettify;
-/// prettify(String::from("ma1 ma2 ma3 ma4 ma")); // --> mā má mǎ mà ma
+/// prettify("ma1 ma2 ma3 ma4 ma"); // --> mā má mǎ mà ma
 /// ```
-pub fn prettify(text: String) -> String {
+pub fn prettify(text: &str) -> String {
     let medials: &str = "iuüIUÜ";
 
     let text = text.replace('v', "ü");


### PR DESCRIPTION
`String` can automatically be dereferenced to a `&str` so `prettify(&String::from("ni3"))` still works.